### PR TITLE
Fix XIF mem and result valid signals

### DIFF
--- a/src/fpu_ss.sv
+++ b/src/fpu_ss.sv
@@ -438,6 +438,7 @@ module fpu_ss
       // Memory Request/Repsonse Interface
       .x_mem_valid_o    (x_mem_valid_o),
       .x_mem_ready_i    (x_mem_ready_i),
+      .x_mem_req_id_i   (x_mem_req_o.id),
       .x_mem_req_we_o   (x_mem_req_o.we),
       .x_mem_req_spec_o (x_mem_req_o.spec),
       .x_mem_req_last_o (x_mem_req_o.last),


### PR DESCRIPTION
Fix the `x_mem_valid_o` signal so that it waits for a valid commit signal.
Fix the `x_result_valid_o` signal so that it also gets triggered when a memory transaction has finished.