### PR TITLE
Fix mem_req.id signal width

### DIFF
--- a/src/fpu_ss_controller.sv
+++ b/src/fpu_ss_controller.sv
@@ -65,7 +65,7 @@ module fpu_ss_controller
     // Memory Request/Repsonse Interface
     output logic x_mem_valid_o,
     input  logic x_mem_ready_i,
-    input  logic x_mem_req_id_i,
+    input  logic [X_ID_WIDTH-1:0] x_mem_req_id_i,
     output logic x_mem_req_we_o,
     output logic x_mem_req_spec_o,
     output logic x_mem_req_last_o,


### PR DESCRIPTION
I made a mistake in #3 . This fixes the width of that signal.